### PR TITLE
Fix 'Invalid Amount' from withdraw

### DIFF
--- a/includes/coin-adapter-rpc.php
+++ b/includes/coin-adapter-rpc.php
@@ -320,7 +320,8 @@ CFG;
 					throw new Exception( sprintf( __( '%s->%s() failed to unlock with status="%s" and error="%s"', 'wallets' ), __CLASS__, __FUNCTION__, $this->rpc->status, $this->rpc->error ) );
 				}
 			}
-
+			
+			$amount = number_format((float) $amount, 8, '.', '');
 			$result = $this->rpc->sendtoaddress(
 				"$address",
 				floatval( $amount ),


### PR DESCRIPTION
The amount value can have up to 8 digits! Bitcoin has a maximum of 8 decimal places.
This fix prevents the 'Invalid Amount' error from the RPC server